### PR TITLE
add body to requests

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,4 +1,5 @@
-route: "http://www.xaas.ir"
-hits: 200
+route: "http://127.0.0.1:8000/"
+hits: 1
 code: 200
 method: post
+# body: {"limit": 10}

--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,5 @@
-route: "http://127.0.0.1:8000/"
-hits: 1
+route: "http://www.xaas.ir"
+hits: 200
 code: 200
 method: post
 body: {"limit": 10}

--- a/config.yaml
+++ b/config.yaml
@@ -2,4 +2,4 @@ route: "http://127.0.0.1:8000/"
 hits: 1
 code: 200
 method: post
-# body: {"limit": 10}
+body: {"limit": 10}


### PR DESCRIPTION
Now users can add body to their requests. Content type of requests are "application/json" by default and users can't change that for now.  If user doesn't enter a value for `body` in `config.yaml` file, the value of body will be an empty json object (`{}`)