### PR TITLE
add unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,13 @@
 use this appication to stress test your api
 
 writeen by Arash Rasoulzadeh
+
+## Example usage
+
+#### Run with a single thread:
+`go run main.go single`
+
+#### Run using multiple threads:
+*runs using 4 threads*
+
+`go run main.go multiple 4`

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+)
+
+const (
+	conf_file_path = "./testutils/config.test.yaml"
+)
+
+func TestGetConf(t *testing.T) {
+	var c conf
+	c.getConf(conf_file_path)
+	if c.Code != 200 {
+		t.Error("Wrong value for - Code -")
+	}
+
+	if c.Hits != 50 {
+		t.Error("Wrong value for - Hits -")
+	}
+
+	if strings.ToUpper(c.Method) != http.MethodGet {
+		t.Error("Wrong value for - Method -")
+	}
+
+	if c.Route != "test_route" {
+		t.Error("Wrong value for - Route -")
+	}
+}

--- a/testutils/config.test.yaml
+++ b/testutils/config.test.yaml
@@ -1,0 +1,5 @@
+route: "test_route"
+hits: 50
+code: 200
+method: get
+body: {"limit": 10}


### PR DESCRIPTION
1. `README.md` was updated and some examples are added.
2. `getConf` method of `conf` struct is changed to receive path to config file through it's arguments. *why?* -> it makes writing unit tests easier.
3. `wg` parameter is deleted from `SendHttpRequest` function. *why?* -> it was unused.
4. A new directory called *testutils* is added which holds files and utilities which are useful in unit tests.